### PR TITLE
Pins filtering

### DIFF
--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -23,11 +23,15 @@ function setMarkers() {
   }
   markers.push(map.center);
 
-  let bounds = new google.maps.LatLngBounds();
-  for (var i = 0; i < markers.length; i++) {
-    bounds.extend(markers[i]);
+  // Prevent zoom from changing if user input pin is the only location
+  if(markersObject.length>0){
+    // Zoom to all pins shown (need at least 2 to work)
+    let bounds = new google.maps.LatLngBounds();
+    for (var i = 0; i < markers.length; i++) {
+      bounds.extend(markers[i]);
+    }
+    map.fitBounds(bounds);
   }
-  map.fitBounds(bounds);
 
   // refresh storage for next time
   let newLocations = new Array();

--- a/public/javascripts/search.js
+++ b/public/javascripts/search.js
@@ -1,3 +1,8 @@
+/** Global variables for resetting pins on the map
+* @var markersObject 
+*/
+  let markersObject;
+
 /** Function to set markers on the map for all park locations
 * @function setMarkers
 */
@@ -5,6 +10,7 @@ function setMarkers() {
   let iconBase = "http://maps.google.com/mapfiles/kml/paddle/";
   let locations = JSON.parse(localStorage.getItem("locations"));
   let markers = new Array();
+  markersObject = new Array();
   console.log("In map.js, setMarkers() ", locations);
   for (let i = 0; i < locations.length; i++) {
     let marker = new google.maps.Marker({
@@ -13,6 +19,7 @@ function setMarkers() {
       map: map,
     });
     markers.push(marker.position);
+    markersObject.push(marker);
   }
   markers.push(map.center);
 
@@ -25,15 +32,16 @@ function setMarkers() {
   // refresh storage for next time
   let newLocations = new Array();
   localStorage.setItem("locations", JSON.stringify(newLocations));
+}
 
-  /*
-
-   // clear any current markers from the map but leave them in the array
-  for (let i = 0; i < locations.length; i++) {
-    locations[i].setMap(map);
+function resetPins(){
+  // clear any current markers from the map
+  for (let i = 0; i < markersObject.length; i++) {
+    markersObject[i].setMap(null);
   }
-
-  */
+  // clear the arrays
+  markersObject = [];
+  markers = [];
 }
 
 /** Function to calculate current geo location of the user
@@ -228,10 +236,13 @@ fetch( `https://developer.nps.gov/api/v1/topics?limit=83&api_key=${ nps_token }`
     console.log(err);
   });
 
-/** Function to get the checked checkbox values for activities and interests
+/** Function to get the checked checkbox values for activities and interests and start the filtering processes
 * @function ai_checkbox 
 */
 function ai_checkboxes() {
+  // remove all pins (besides the user inputted one) before deciding which ones to add back
+  resetPins();
+  // remove all text results before adding them back
   resetResults();
   let resultsCheckDuplicates = new Array();
 


### PR DESCRIPTION
Update the map markers to be in accordance with the result list
In **search.js**

**The main parts of how this works**
- Add a function to remove all pins (besides the center) before filtering starts so they can be added back as needed
- Locations for pins are stored in activitiesFilter() and interestFilter() as already implemented in parks()
- Create an async / await relationship between the two filters to ensure activities finishes before interests starts
- If only the activitiesFilter() is needed, go to setMarkers() from activitiesFilter()
- Otherwise go to setMarkers() from interestFilter()

**Other related changes**
- Small edits in comments for spelling
- Prevent zoom from changing if user input pin is the only location by ensuring there is 1 marker in the array that doesn't include the center (markersObject) - bounds.extend only works with 2+ pins